### PR TITLE
Handling multiple taxon as a list

### DIFF
--- a/mapmaker/properties/__init__.py
+++ b/mapmaker/properties/__init__.py
@@ -224,7 +224,7 @@ class PropertiesStore(object):
                      label += '\n' + feature_properties.get('name', '')
                 feature_properties['label'] = label
             if (taxon := knowledge.get('taxon')) is not None:
-                feature_properties['taxons'] = [taxon]
+                feature_properties['taxons'] = taxon if isinstance(taxon, list) else [taxon]
         elif 'label' not in feature_properties and 'name' in feature_properties:
             feature_properties['label'] = feature_properties['name']
             name_used = True


### PR DESCRIPTION
Regarding this problem: https://nih-sparc.slack.com/archives/GL6GVJH36/p1711593607001789?thread_ts=1711585670.164379&cid=GL6GVJH36

Mapknowledge can produce a list of taxon related to a neuron population while in map-maker this is handled as a string.