### PR TITLE
Mapmaker can specify the mapknowledge source.

### DIFF
--- a/mapmaker/flatmap/manifest.py
+++ b/mapmaker/flatmap/manifest.py
@@ -174,10 +174,10 @@ class Manifest:
             elif 'id' not in self.__manifest:
                 raise ValueError('No `id` specified in manifest')
 
-            if self.__manifest.get('sckan-version', 'production') not in ['production', 'staging']:
-                raise ValueError("'sckan-version' in manifest must be `production' or 'staging'")
-            for model in self.__manifest.get('neuronConnectivity', []):
-                self.__neuron_connectivity.append(model)
+            if self.__manifest.get('sckan-version', '') in ['production', 'staging']:
+                self.__neuron_connectivity = self.__manifest.get('neuronConnectivity', [])
+            else :
+                self.__neuron_connectivity = ['NPO']
 
             if 'sources' not in self.__manifest:
                 raise ValueError('No sources given for manifest')

--- a/mapmaker/maker.py
+++ b/mapmaker/maker.py
@@ -152,11 +152,21 @@ class MapMaker(object):
 
         # Our source of knowledge, updated with information about maps we've made, held in a global place
         sckan_version = settings.get('sckanVersion', self.__manifest.sckan_version)
-        knowledge_store = knowledgebase.KnowledgeStore(map_base,
-                                         clean_connectivity=settings.get('cleanConnectivity', False),
-                                         sckan_version=sckan_version,
-                                         npo=True,
-                                         log_build=True)
+        if sckan_version in ['production', 'staging']:
+            knowledge_store = knowledgebase.KnowledgeStore(map_base,
+                                            clean_connectivity=settings.get('cleanConnectivity', False),
+                                            sckan_version=sckan_version,
+                                            npo=True,
+                                            log_build=True,
+                                            )
+        else:
+            knowledge_store = knowledgebase.KnowledgeStore(map_base,
+                                            clean_connectivity=settings.get('cleanConnectivity', False),
+                                            npo=True,
+                                            log_build=True,
+                                            scicrunch_api=None,
+                                            npo_release=sckan_version
+                                            )
         settings['KNOWLEDGE_STORE'] = knowledge_store
 
         self.__sckan_provenance = knowledgebase.sckan_provenance()
@@ -173,6 +183,10 @@ class MapMaker(object):
                             + self.__sckan_provenance['sckan']['date']))
         else:
             self.__uuid = None
+
+        # Checking sckan-version
+        if sckan_version not in ['production', 'staging', self.__sckan_provenance.get('npo', {}).get('release', '')]:
+            raise ValueError("'sckan-version' in manifest must be `production', 'staging', or any valid tag release")
 
         # Where the generated map is saved
         self.__map_dir = os.path.join(map_base, self.__uuid if self.__uuid is not None else self.__id)


### PR DESCRIPTION
With this PR, mapmaker can specify the mapknowledge source through `sckan-version` field in manifest. This will allow:

- Using `production` and `staging` keywords, i.e. `"sckan-version": "production"` and `"sckan-version": "staging"`. With this setting, mapmaker generates flatmap with the original approach, combining scicrunch and npo
- Using github release tag, e.g. `"sckan-version":"sckan-2024-03-26"`. With this setting, mapmaker generates flatmap using knowledge from the github release only.

In a case that the github release tag is not found, the flatmap generation will be terminated.