### PR TITLE
Add the required SHAPE_TYPE, i.e. FEATURE and LAYER to create FC map

### DIFF
--- a/mapmaker/routing/__init__.py
+++ b/mapmaker/routing/__init__.py
@@ -1122,10 +1122,13 @@ class Network(object):
                             feature_distances[f] = sum(distances)/len(distances)
                         selected_feature = min(feature_distances, key=feature_distances.get)    # type: ignore
                 else:
-                    if len(prev_features) > 0 and len(features) > 1:
-                        min_distance = prev_features[-1].geometry.centroid.distance(features[0].geometry.centroid)
-                        for f in (features:=[f for f in features[1:]]):
-                            if (distance:=prev_features[-1].geometry.centroid.distance(f.geometry.centroid)) < min_distance:
+                    min_distance = None
+                    for f in features:
+                        if (f_ftu:=get_ftu_node(f)) in prev_features:
+                            return f_ftu
+                        if len(prev_features) > 0:
+                            distance = prev_features[-1].geometry.centroid.distance(f.geometry.centroid)
+                            if min_distance is None or distance < min_distance:
                                 min_distance = distance
                                 selected_feature = f
                     return get_ftu_node(selected_feature)

--- a/mapmaker/routing/__init__.py
+++ b/mapmaker/routing/__init__.py
@@ -1106,7 +1106,6 @@ class Network(object):
 
         # select the closest feature of a node with multiple features to it's neighbors
         def get_node_feature(node_dict, neighbours, prev_features) -> Feature:
-            print(node_dict["name"], neighbours, prev_features)
             (features:=list(f for f in node_dict['features'])).sort(key=lambda f: f.id)
             selected_feature = features[0]
             # in a case of a terminal node having multiple features, select the closest one to it's neighbours

--- a/mapmaker/shapes/__init__.py
+++ b/mapmaker/shapes/__init__.py
@@ -40,6 +40,8 @@ class SHAPE_TYPE(str, Enum):   ## Or IntEnum ??
     IMAGE      = 'image'
     TEXT       = 'text'
     UNKNOWN    = 'unknown'
+    FEATURE    = 'feature'
+    LAYER      = 'layer'
 
 #===============================================================================
 

--- a/mapmaker/sources/powerpoint/__init__.py
+++ b/mapmaker/sources/powerpoint/__init__.py
@@ -43,6 +43,7 @@ from .powerpoint import Slide
 
 def set_relationship_property(feature, property, relatives):
     geojson_ids = set(s.global_shape.geojson_id for s in relatives if s.global_shape.geojson_id)
+    geojson_ids = set(s.properties.get('geojson_id') for s in relatives if s.properties.get('geojson_id') is not None)
     if feature.has_property(property):
         feature.get_property(property).update(geojson_ids)
     else:


### PR DESCRIPTION
In SHA bf3f30b, the FEATURE and LAYER attributes in SHAPE_TYPE are missing.
However, these attributes are required when creating an FC map, for example:
https://github.com/AnatomicMaps/flatmap-maker/blob/4503fb4dd079579bf94de2b9bc58e90e3b1ed945/mapmaker/sources/fc_powerpoint/__init__.py#L157