### PR TITLE
Issue #116: Add --path-arrows option for arrow rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,6 @@ Command line help
                             Create a SPARC Dataset containing the map's sources and the generated map
       --sckan-version {production,staging}
                             Overide version of SCKAN specified by map's manifest
-      --path-arrows         Render arrows at the terminal nodes of paths
 
     Diagnostics:
       --authoring           For use when checking a new map: highlight incomplete

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Command line help
                             Create a SPARC Dataset containing the map's sources and the generated map
       --sckan-version {production,staging}
                             Overide version of SCKAN specified by map's manifest
-      --path-arrows         ReRender arrows at the terminal nodes of paths
+      --path-arrows         Render arrows at the terminal nodes of paths
 
     Diagnostics:
       --authoring           For use when checking a new map: highlight incomplete

--- a/README.rst
+++ b/README.rst
@@ -107,15 +107,14 @@ Command line help
 
     usage: mapmaker [-h] [-v]
                     [--log LOG_FILE] [--silent] [--verbose]
-                    [--background-tiles] [--clean-connectivity] [--disconnected-paths]
-                    [--force] [--id ID] [--ignore-git] [--ignore-sckan] [--invalid-neurons]
-                    [--no-path-layout] [--publish SPARC_DATASET] [--sckan-version {production,staging}]
+                    [--background-tiles] [--clean-connectivity] [--disconnected-paths] [--force]
+                    [--id ID] [--ignore-git] [--ignore-sckan] [--invalid-neurons] [--no-path-layout]
+                    [--path-arrows] [--publish SPARC_DATASET] [--sckan-version {production,staging}]
                     [--authoring] [--debug]
                     [--only-networks] [--save-drawml] [--save-geojson] [--tippecanoe]
                     [--initial-zoom N] [--max-zoom N]
                     [--export-features EXPORT_FILE] [--export-neurons EXPORT_FILE] [--export-svg EXPORT_FILE]
                     [--single-file {celldl,svg}]
-                    [--path-arrows]
                     --output OUTPUT --source SOURCE
 
     Generate a flatmap from its source manifest.

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,7 @@ Command line help
       --invalid-neurons     Include functional connectivity neurons that aren't known
                             in SCKAN
       --no-path-layout      Don't do `TransitMap` optimisation of paths
+      --path-arrows         Render arrows at the terminal nodes of paths
       --publish SPARC_DATASET
                             Create a SPARC Dataset containing the map's sources and the generated map
       --sckan-version {production,staging}

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ Command line help
                     [--initial-zoom N] [--max-zoom N]
                     [--export-features EXPORT_FILE] [--export-neurons EXPORT_FILE] [--export-svg EXPORT_FILE]
                     [--single-file {celldl,svg}]
+                    [--path-arrows]
                     --output OUTPUT --source SOURCE
 
     Generate a flatmap from its source manifest.
@@ -145,6 +146,7 @@ Command line help
                             Create a SPARC Dataset containing the map's sources and the generated map
       --sckan-version {production,staging}
                             Overide version of SCKAN specified by map's manifest
+      --path-arrows         Render arrows at the terminal nodes.
 
     Diagnostics:
       --authoring           For use when checking a new map: highlight incomplete

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Command line help
                             Create a SPARC Dataset containing the map's sources and the generated map
       --sckan-version {production,staging}
                             Overide version of SCKAN specified by map's manifest
-      --path-arrows         Render arrows at the terminal nodes.
+      --path-arrows         ReRender arrows at the terminal nodes of paths
 
     Diagnostics:
       --authoring           For use when checking a new map: highlight incomplete

--- a/mapmaker/__main__.py
+++ b/mapmaker/__main__.py
@@ -64,7 +64,7 @@ def arg_parser():
     generation_options.add_argument('--sckan-version', dest='sckanVersion', choices=['production', 'staging'],
                         help="Overide version of SCKAN specified by map's manifest")
     generation_options.add_argument('--path-arrows', dest='pathArrows', action='store_true',
-                        help="Render arrows at the terminal nodes.")
+                        help="Render arrows at the terminal nodes of paths")
 
     debug_options = parser.add_argument_group('Diagnostics')
     debug_options.add_argument('--authoring', action='store_true',

--- a/mapmaker/__main__.py
+++ b/mapmaker/__main__.py
@@ -63,6 +63,8 @@ def arg_parser():
                         help="Create a SPARC Dataset containing the map's sources and the generated map")
     generation_options.add_argument('--sckan-version', dest='sckanVersion', choices=['production', 'staging'],
                         help="Overide version of SCKAN specified by map's manifest")
+    generation_options.add_argument('--path-arrow', dest='pathArrow', action='store_true',
+                        help="Render arrows at the terminal nodes.")
 
     debug_options = parser.add_argument_group('Diagnostics')
     debug_options.add_argument('--authoring', action='store_true',

--- a/mapmaker/__main__.py
+++ b/mapmaker/__main__.py
@@ -59,12 +59,12 @@ def arg_parser():
                         help="Include functional connectivity neurons that aren't known in SCKAN")
     generation_options.add_argument('--no-path-layout', dest='noPathLayout', action='store_true',
                         help="Don't do `TransitMap` optimisation of paths")
+    generation_options.add_argument('--path-arrows', dest='pathArrows', action='store_true',
+                        help="Render arrows at the terminal nodes of paths")
     generation_options.add_argument('--publish', metavar='SPARC_DATASET',
                         help="Create a SPARC Dataset containing the map's sources and the generated map")
     generation_options.add_argument('--sckan-version', dest='sckanVersion', choices=['production', 'staging'],
                         help="Overide version of SCKAN specified by map's manifest")
-    generation_options.add_argument('--path-arrows', dest='pathArrows', action='store_true',
-                        help="Render arrows at the terminal nodes of paths")
 
     debug_options = parser.add_argument_group('Diagnostics')
     debug_options.add_argument('--authoring', action='store_true',

--- a/mapmaker/__main__.py
+++ b/mapmaker/__main__.py
@@ -63,7 +63,7 @@ def arg_parser():
                         help="Create a SPARC Dataset containing the map's sources and the generated map")
     generation_options.add_argument('--sckan-version', dest='sckanVersion', choices=['production', 'staging'],
                         help="Overide version of SCKAN specified by map's manifest")
-    generation_options.add_argument('--path-arrow', dest='pathArrow', action='store_true',
+    generation_options.add_argument('--path-arrows', dest='pathArrows', action='store_true',
                         help="Render arrows at the terminal nodes.")
 
     debug_options = parser.add_argument_group('Diagnostics')

--- a/mapmaker/routing/routedpath.py
+++ b/mapmaker/routing/routedpath.py
@@ -480,7 +480,7 @@ class RoutedPath(object):
                     end_coords = self.__graph.nodes[terminal_node]['geometry'].centroid.coords[0]
                     end_point = coords_to_point(end_coords)
                     heading = (end_point - start_point).angle
-                    bz_end_point = end_point - BezierPoint.fromAngle(heading) * 0.9 * ARROW_LENGTH if settings.get('pathArrows', False) else end_point
+                    bz_end_point = (end_point - BezierPoint.fromAngle(heading) * 0.9 * ARROW_LENGTH) if settings.get('pathArrows', False) else end_point
                     bz = bezier_connect(start_point, bz_end_point, angle, heading)
                     path_geometry[path_id].append(GeometricShape(
                         bezier_to_linestring(bz), {

--- a/mapmaker/routing/routedpath.py
+++ b/mapmaker/routing/routedpath.py
@@ -417,14 +417,15 @@ class RoutedPath(object):
 
         # Draw paths to terminal nodes
         def draw_arrow(start_point, end_point, path_id, path_source):
-            heading = (end_point - start_point).angle
-            end_point -= BezierPoint.fromAngle(heading)*0.9*ARROW_LENGTH
-            path_geometry[path_id].append(GeometricShape.arrow(end_point, heading, ARROW_LENGTH, properties={
-                'type': 'arrow',
-                'path-id': path_id,
-                'source': path_source,
-                'label': self.__graph.graph.get('label')
-            }))
+            if settings.get('pathArrow', False):
+                heading = (end_point - start_point).angle
+                end_point -= BezierPoint.fromAngle(heading)*0.9*ARROW_LENGTH
+                path_geometry[path_id].append(GeometricShape.arrow(end_point, heading, ARROW_LENGTH, properties={
+                    'type': 'arrow',
+                    'path-id': path_id,
+                    'source': path_source,
+                    'label': self.__graph.graph.get('label')
+                }))
 
         def draw_line(node_0, node_1, tolerance=0.1, separation=2000):
             start_coords = self.__graph.nodes[node_0]['geometry'].centroid.coords[0]
@@ -479,8 +480,7 @@ class RoutedPath(object):
                     end_coords = self.__graph.nodes[terminal_node]['geometry'].centroid.coords[0]
                     end_point = coords_to_point(end_coords)
                     heading = (end_point - start_point).angle
-                    bz_end_point = end_point - BezierPoint.fromAngle(heading)*0.9*ARROW_LENGTH
-                    bz = bezier_connect(start_point, bz_end_point, angle, heading)
+                    bz = bezier_connect(start_point, end_point, angle, heading)
                     path_geometry[path_id].append(GeometricShape(
                         bezier_to_linestring(bz), {
                             'path-id': path_id,

--- a/mapmaker/routing/routedpath.py
+++ b/mapmaker/routing/routedpath.py
@@ -480,7 +480,7 @@ class RoutedPath(object):
                     end_coords = self.__graph.nodes[terminal_node]['geometry'].centroid.coords[0]
                     end_point = coords_to_point(end_coords)
                     heading = (end_point - start_point).angle
-                    bz_end_point = end_point - BezierPoint.fromAngle(heading) * 0.9 * ARROW_LENGTH if settings.get('pathArrows') else end_point
+                    bz_end_point = end_point - BezierPoint.fromAngle(heading) * 0.9 * ARROW_LENGTH if settings.get('pathArrows', False) else end_point
                     bz = bezier_connect(start_point, bz_end_point, angle, heading)
                     path_geometry[path_id].append(GeometricShape(
                         bezier_to_linestring(bz), {

--- a/mapmaker/routing/routedpath.py
+++ b/mapmaker/routing/routedpath.py
@@ -417,7 +417,7 @@ class RoutedPath(object):
 
         # Draw paths to terminal nodes
         def draw_arrow(start_point, end_point, path_id, path_source):
-            if settings.get('pathArrow', False):
+            if settings.get('pathArrows', False):
                 heading = (end_point - start_point).angle
                 end_point -= BezierPoint.fromAngle(heading)*0.9*ARROW_LENGTH
                 path_geometry[path_id].append(GeometricShape.arrow(end_point, heading, ARROW_LENGTH, properties={
@@ -480,7 +480,8 @@ class RoutedPath(object):
                     end_coords = self.__graph.nodes[terminal_node]['geometry'].centroid.coords[0]
                     end_point = coords_to_point(end_coords)
                     heading = (end_point - start_point).angle
-                    bz = bezier_connect(start_point, end_point, angle, heading)
+                    bz_end_point = end_point - BezierPoint.fromAngle(heading) * 0.9 * ARROW_LENGTH if settings.get('pathArrows') else end_point
+                    bz = bezier_connect(start_point, bz_end_point, angle, heading)
                     path_geometry[path_id].append(GeometricShape(
                         bezier_to_linestring(bz), {
                             'path-id': path_id,


### PR DESCRIPTION
Issue #116 

- Updated the draw_arrow() function to do nothing by default. Introduced a new --path-arrows argument to enable arrow rendering on paths. Updated the README to reflect the usage of this new option.
- Check circular path integrity by verifying centerline and nodes to ensure circularity. This resolves rendering issues with keast-4 and corrects rendering for `unbranched-20` and `unbranched-21`. The following figure illustrates the `keast-4` path before and after the update.

`keast-4` before update
<img width="960" alt="Screenshot 2025-02-17 at 12 26 50 PM" src="https://github.com/user-attachments/assets/e15f8d06-3c45-40fa-9eee-956cc17e9cef" />

`keast-4` after update
<img width="764" alt="Screenshot 2025-02-17 at 12 29 02 PM" src="https://github.com/user-attachments/assets/557988b8-73fa-414d-88b2-a388b9ec9dc5" />
