### PR TITLE
Align rendered connectivity extraction with highlighted nodes

### DIFF
--- a/mapmaker/flatmap/__init__.py
+++ b/mapmaker/flatmap/__init__.py
@@ -252,6 +252,8 @@ class FlatMap(object):
             if len(fts:=set(feature for feature in self.__features_with_id.values()
                             if feature.models in [features[0][0]]+list(features[0][1])
                             and feature.get_property('kind')=='proxy')) > 0:
+                for f in fts:
+                    f.add_anatomical_node(anatomical_node)
                 return (features[0], fts)
             return features
 


### PR DESCRIPTION
#151 

This update aligns the rendered connectivity extraction process with the highlighted nodes by restructuring and refining related methods:

- Moved rendered connectivity extraction from the `Pathways` class to `ResolvedPathways` to ensure all rendered connectivity nodes are consistent with `ResolvedPathways` nodes.
- Renamed the moved method from `__extract_rendered_connectivity` to `__resolved_rendered_connectivity`.
- Extracted node hierarchy logic from `__resolved_rendered_connectivity` and placed it within `__route_network_connectivity`.
- Tracked connections between `ResolvedPathways` nodes and rendered connectivity nodes via features' `anatomical_nodes` attributes.
- Added proxy-related nodes to the `anatomical_nodes` attribute, which were previously missing, improving node linkage accuracy.