### PR TITLE
Support node lookup using both node and node['node'], allowing alias anatomical_node resolution

### DIFF
--- a/mapmaker/properties/pathways.py
+++ b/mapmaker/properties/pathways.py
@@ -329,8 +329,8 @@ class ResolvedPathways:
 
         # remove the missing nodes:
         removed_nodes = []
-        for node in connectivity_graph.nodes:
-            if node not in available_nodes:
+        for node, node_dict in connectivity_graph.nodes(data=True):
+            if node not in available_nodes and node_dict['node'] not in available_nodes:
                 removed_nodes += [node]
                 neighbors = list(connectivity_graph.neighbors(node))
                 predecessors = [n for n in neighbors if n == connectivity_graph.edges[(node, n)]['predecessor']]


### PR DESCRIPTION
#159

Found that the simplest way to fix the missing rendered-connectivity information is to consider both the anatomical_node name and the node used in node_dict. With this approach, anatomical_nodes that were modified to aliases can still be resolved.